### PR TITLE
Extra logging for declared and selected columns

### DIFF
--- a/corc-core/src/main/java/com/hotels/corc/mapred/CorcInputFormat.java
+++ b/corc-core/src/main/java/com/hotels/corc/mapred/CorcInputFormat.java
@@ -168,6 +168,7 @@ public class CorcInputFormat implements InputFormat<NullWritable, Corc> {
    */
   static void setReadColumns(Configuration conf, StructTypeInfo actualStructTypeInfo) {
     StructTypeInfo readStructTypeInfo = getTypeInfo(conf);
+    LOG.info("Read StructTypeInfo: {}", readStructTypeInfo);
 
     List<Integer> ids = new ArrayList<>();
     List<String> names = new ArrayList<>();
@@ -189,8 +190,11 @@ public class CorcInputFormat implements InputFormat<NullWritable, Corc> {
         ids.add(i);
         names.add(actualName);
       }
-      LOG.debug("Set column projection on columns: {} ({})", ids, readNames);
     }
+    if (ids.size() == 0) {
+      throw new IllegalStateException("None of the selected columns were found in the ORC file.");
+    }
+    LOG.info("Set column projection on columns: {} ({})", ids, names);
     ColumnProjectionUtils.appendReadColumns(conf, ids, names);
   }
 
@@ -215,8 +219,10 @@ public class CorcInputFormat implements InputFormat<NullWritable, Corc> {
   public RecordReader<NullWritable, Corc> getRecordReader(InputSplit inputSplit, JobConf conf, Reporter reporter)
       throws IOException {
     StructTypeInfo typeInfo = getSchemaTypeInfo(conf);
+    LOG.info("Conf StructTypeInfo: {}", typeInfo);
     if (typeInfo == null) {
       typeInfo = readStructTypeInfoFromSplit(inputSplit, conf);
+      LOG.info("File StructTypeInfo: {}", typeInfo);
     }
     setReadColumns(conf, typeInfo);
     RecordReader<NullWritable, OrcStruct> reader = orcInputFormat.getRecordReader(inputSplit, conf, reporter);

--- a/corc-core/src/test/java/com/hotels/corc/mapred/CorcInputFormatTest.java
+++ b/corc-core/src/test/java/com/hotels/corc/mapred/CorcInputFormatTest.java
@@ -266,6 +266,18 @@ public class CorcInputFormatTest {
   }
 
   @Test(expected = IllegalStateException.class)
+  public void setInputReadColumnsAllMissing() {
+    StructTypeInfo typeInfo = new StructTypeInfoBuilder()
+        .add("a", TypeInfoFactory.stringTypeInfo)
+        .add("b", TypeInfoFactory.longTypeInfo)
+        .build();
+
+    conf.set(CorcInputFormat.INPUT_TYPE_INFO, "struct<_col0:string,_col1:bigint>");
+
+    CorcInputFormat.setReadColumns(conf, typeInfo);
+  }
+
+  @Test(expected = IllegalStateException.class)
   public void setInputReadColumnsDifferentTypes() {
     StructTypeInfo typeInfo = new StructTypeInfoBuilder().add("a", TypeInfoFactory.stringTypeInfo).build();
 


### PR DESCRIPTION
This PR adds some extra logging to show what columns were read from an ORC File's `ObjectInspector` (or declared/overridden columns) and those which are selected for reading.

It also add a small check to fail fast when no columns are selected for reading.