### PR TITLE
set combine input flag to false for OrcFile scheme

### DIFF
--- a/corc-cascading/src/main/java/com/hotels/corc/cascading/OrcFile.java
+++ b/corc-cascading/src/main/java/com/hotels/corc/cascading/OrcFile.java
@@ -146,6 +146,8 @@ public class OrcFile extends Scheme<Configuration, RecordReader, OutputCollector
       Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf) {
     conf.setBoolean("mapred.mapper.new-api", false);
     conf.setClass("mapred.input.format.class", CorcInputFormat.class, InputFormat.class);
+    // ORC cannot be combined.
+    conf.setBoolean("cascading.hadoop.hfs.combine.files", false);
     CorcInputFormat.setSchemaTypeInfo(conf, schemaTypeInfo);
     CorcInputFormat.setTypeInfo(conf, typeInfo);
     CorcInputFormat.setSearchArgumentKryo(conf, searchArgumentKryo);


### PR DESCRIPTION
disabling any attempt to combine input on ORC files as it won't work and it is easy to override in OrcFile saves jobs of having to set it per Source in cascading which is hard